### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/CR004_Directory/README.md
+++ b/CR004_Directory/README.md
@@ -7,7 +7,7 @@
 
 ## Useful Links:
 
-- [CR4 Notes](https://github.com/DipsanaRoy/c-error-handling/main/tree/CR004_Directory/CR4_NOTES.md)
+- [CR4 Notes](https://github.com/DipsanaRoy/c-error-handling/blob/main/CR004_Directory/CR4_NOTES.md)
 
 *Happy Learning!*
 


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.