### PR TITLE
Bugfix: Global README link correction for all chapters and test sets

### DIFF
--- a/CR003_File_IO/README.md
+++ b/CR003_File_IO/README.md
@@ -1,0 +1,14 @@
+
+*Coming Soon!*🥰
+
+<!-- ---
+
+# Kindly Read the Notes Before Proceeding with the Example Programs for Better Understanding
+
+## Useful Links:
+
+- [CR3 Notes](https://github.com/DipsanaRoy/c-error-handling/blob/main/CR003_File_IO/CE3_NOTES.md)
+
+*Happy Learning!*
+
+--- -->

--- a/CR003_File_IO/ce2_perror.c
+++ b/CR003_File_IO/ce2_perror.c
@@ -1,0 +1,12 @@
+// CE2. perror
+#include <stdio.h>
+#include <errno.h>
+
+int main() {
+    FILE *file = fopen("nonexistent.txt", "r");
+
+    if (file == NULL) {
+        perror("Error"); // Prints errno based error message
+    }
+    return 0;
+}


### PR DESCRIPTION
This PR fixes broken links in the README.md files of all subdirectories by replacing `/tree/main/` with `/blob/main/`. This ensures direct file access on GitHub instead of folder views.

- Root README is untouched.
- All chapter and test set folders updated.
- Ensures consistency across branches.

Fixes: Broken navigation issue in GitHub UI.